### PR TITLE
Added robots.txt for prod and staging + travis.yml update. #181

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ script:
 - yarn lint
 - yarn test
 - yarn build
+
+before_deploy:
+- if [[ -z "$TRAVIS_TAG" ]]; then cp robots.txt.staging build/robots.txt; else cp robots.txt build/; fi
+
 deploy:
 - provider: s3
   access_key_id: AKIAIMA7VGNP6PRLOIBQ

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: * 
+Disallow:

--- a/robots.txt.staging
+++ b/robots.txt.staging
@@ -1,0 +1,2 @@
+User-agent: * 
+Disallow: /


### PR DESCRIPTION
Added 2 files: robots.txt (allow everything) and a robots.txt.staging (block all crawling/indexing), and this change to the .travis.yml:

before_deploy:
- if [[ -z "$TRAVIS_TAG" ]]; then cp robots.txt.staging build/robots.txt; else cp robots.txt build/; fi

I am taking an educated guess at the structure of the filesystem in our build. It works for my test travis project.  If the above doesn’t work, I would do this:

before_deploy:
- pwd
- ls
- ls build
- if [[ -z "$TRAVIS_TAG" ]]; then cp robots.txt.staging build/robots.txt; else cp robots.txt build/; fi

Then we could see from the ls output if we are in the root of the project, and that build dir is under this.

If our build changes the CWD, then this would help:

- if [[ -z "$TRAVIS_TAG" ]]; then cp $TRAVIS_BUILD_DIR/robots.txt.staging $TRAVIS_BUILD_DIR/build/robots.txt; else cp $TRAVIS_BUILD_DIR/robots.txt $TRAVIS_BUILD_DIR/build/; fi
