### PR TITLE
Fix html and css errors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <meta charset="utf-8" />
   <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -30,7 +30,6 @@ const Root = ({ locale, ...props }) => (
     <div>
       <Helmet titleTemplate="%s &middot; Skycoin">
         <html lang={locale} />
-        <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -31,14 +31,14 @@ const Button = styled(Link)`
 
   &:hover {
     background-color: ${props =>
-    props.bg && darken(0.05, get(COLORS, props.bg) || props.bg)};
+    (props.bg && darken(0.05, get(COLORS, props.bg) || props.bg)) || 'transparent'};
 
     box-shadow: ${BOX_SHADOWS.hover};
   }
 
   &:active {
     background-color: ${props =>
-    props.bg && darken(0.1, get(COLORS, props.bg) || props.bg)};
+    (props.bg && darken(0.1, get(COLORS, props.bg) || props.bg)) || 'transparent'};
   }
 
   ${props => props.outlined && css`

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -17,6 +17,6 @@ export default styled(Heading)`
   ${width}
 
   font-family: ${props => (props.heavy ? `${FONT_FAMILIES.sansBold}` : `${FONT_FAMILIES.sans}`)};
-  font-weight: 'normal';
+  font-weight: 400;
   line-height: ${props => (props.lineHeight ? props.lineHeight : '1.5')};
 `;

--- a/src/components/Home/components/Press/Press.js
+++ b/src/components/Home/components/Press/Press.js
@@ -54,8 +54,8 @@ const Logo = styled.img.attrs({
   src: props => props.src,
 })`
   display: inline-block;
-  margin-top: ${rem(SPACE[4])}px;
-  margin-bottom: ${rem(SPACE[4])}px;
+  margin-top: ${rem(SPACE[4])};
+  margin-bottom: ${rem(SPACE[4])};
   max-width: 100%;
   max-height: 94px;
   
@@ -68,7 +68,7 @@ const Paragraph = styled.p`
   font-weight: 400;
   line-height: 1.5rem;
   margin-bottom: 0.5em;
-  margin-right: ${SPACE[13]};
+  margin-right: ${rem(SPACE[13])};
   text-transform: none;
 `;
 
@@ -78,7 +78,7 @@ const Graphic = styled.img.attrs({
   display: block;
   max-width: 100%;
   max-height: 155px;
-  margin-right: ${rem(SPACE[8])}px;
+  margin-right: ${rem(SPACE[8])};
 `;
 
 const LogosWrapper = styled(Flex)`

--- a/src/components/SubHeading/SubHeading.js
+++ b/src/components/SubHeading/SubHeading.js
@@ -16,7 +16,7 @@ export default styled(SubHeading)`
   ${width}
 
   font-family: ${props => (props.heavy ? `${FONT_FAMILIES.sansBold}` : `${FONT_FAMILIES.sans}`)};
-  font-weight: 'normal';
+  font-weight: 400;
   line-height: 1.5;
   text-transform: uppercase;
   color: ${props => props.color || COLOR.textLight};


### PR DESCRIPTION
1. Set a charset attribute on a meta element after the header
2. CSS: Fix parse error for background-color
3. CSS: Fix font-weight values
4. CSS: Fix typos in dimensions